### PR TITLE
Update pillow version to resolve security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ autodoc
 datetime~=4.3
 h5py~=2.10.0
 pyserial~=3.4
-pillow~=7.0.0
+pillow~=7.1.0
 setuptools~=46.1.3
 pandas~=1.0.3
 scipy~=1.4.1


### PR DESCRIPTION
This would fix the known security vulnerability issue and stop the weekly "Dependabot alerts" from GitHub.